### PR TITLE
Add Twitch plays zen mode awareness

### DIFF
--- a/Assets/theSwanScript.cs
+++ b/Assets/theSwanScript.cs
@@ -89,6 +89,7 @@ public class theSwanScript : MonoBehaviour
 		bool solveLogged = false;
 		int systemResetCounter = 0;
 		bool solved = false;
+        string[] ignoredModules = { "Souvenir", "Forget Me Not", "Turn The Key", "The Swan" };
 
 		//Logging
 		static int moduleIdCounter = 1;
@@ -116,7 +117,7 @@ public class theSwanScript : MonoBehaviour
 
 		void Start()
 		{
-				allModuleCount = Bomb.GetModuleNames().Count;
+				allModuleCount = Bomb.GetModuleNames().Count(x => !ignoredModules.Contains(x));
 				if (allModuleCount == 0)
 				{
 						allModuleCount = 1;
@@ -137,7 +138,7 @@ public class theSwanScript : MonoBehaviour
 
 		void Update()
 		{
-				allSolvedModules = Bomb.GetSolvedModuleNames().Count;
+				allSolvedModules = Bomb.GetSolvedModuleNames().Count(x => !ignoredModules.Contains(x));
 				if (beepReady == true && digit3Time == 4 && digit4Time == 2)
 				{
 				alarmCoroutine = StartCoroutine(alarmChecker());

--- a/Assets/theSwanScript.cs
+++ b/Assets/theSwanScript.cs
@@ -151,7 +151,7 @@ public class theSwanScript : MonoBehaviour
 				}
 				timeRemaining = Bomb.GetTime();
 
-				if (timeRemaining < 180 && timeOut == false && digit3Time > 4 && digit3Time < 10 && readyToSolve == false)
+				if (TwitchZenMode == false && timeRemaining < 180 && timeOut == false && digit3Time > 4 && digit3Time < 10 && readyToSolve == false)
 				{
 						readyToSolve = true;
 						Debug.LogFormat("[The Swan #{0}] Ready to solve!", moduleId);
@@ -946,6 +946,7 @@ public class theSwanScript : MonoBehaviour
         StartCoroutine(failsafe());
     }
 
+    private bool TwitchZenMode = false;
     private string TwitchHelpMessage = "Execute the command with !{0} execute 5 12 2 7 9 4. Get the actual time remaining with !{0} time. (Buttons are in reading order from 1-6 top row, 7-12 bottom row.)";
     private IEnumerator ProcessTwitchCommand(string command)
     {


### PR DESCRIPTION
In practical terms, the bomb starts off with 1 second, and counts up.  In other words, the bomb is not exploding due to time.  Also, there is no limit to the number of strikes either, as it is meant to be a peaceful mode.  The only way out is to exit back to setup screen, detonate the bomb with the detonate command, or in the case of a mission that deosn't define factory infinite sequence mode, solve every bomb on the mission.

The change here makes it so The Swan does NOT do the less than 3 minute reset when in Twitch Plays zen mode.